### PR TITLE
DONE!!!

### DIFF
--- a/minishell/a.txt
+++ b/minishell/a.txt
@@ -1,5 +1,0 @@
-kdhkj
-dhfakjleh
-dajfkln
-kldhjfiue
-

--- a/minishell/src/builtin/builtin_export.c
+++ b/minishell/src/builtin/builtin_export.c
@@ -2,6 +2,7 @@
 
 void		exec_export(t_data *data, char *export);
 static int	is_exist(t_data *data, char	*export);
+static char	*get_env_key(char *env);
 
 void	builtin_export(t_data *data, t_node *node)
 {
@@ -44,20 +45,34 @@ void	exec_export(t_data *data, char *export)
 	data->envp = new_envp;
 	free_tab(tmp);
 }
-/*tjrrbdi rhcu*/
+
 static int	is_exist(t_data *data, char	*export)
 {
 	int		i;
+	char	*tmp;
 
 	i = 0;
 	while (data->envp[i])
 	{
-		if (!ft_strncmp(data->envp[i], export, ft_strlen(export)))
+		tmp = get_env_key(export);
+		if (!ft_strncmp(data->envp[i], tmp, ft_strlen(tmp)))
 		{
+			free(tmp);
 			data->envp[i] = ft_strdup(export);
 			return (1);
 		}
+		free(tmp);
 		i++;
 	}
 	return (0);
+}
+
+static char	*get_env_key(char *env)
+{
+	char	*key;
+	char	*tmp;
+
+	tmp = ft_strchr(env, '=');
+	key = ft_substr(env, 0, tmp - env);
+	return (key);
 }

--- a/minishell/src/utils/ft_function.c
+++ b/minishell/src/utils/ft_function.c
@@ -2,6 +2,8 @@
 
 void	ft_pipe(t_data *data, t_node *node)
 {
+	if (node->idx == -1)
+		return ;
 	if (pipe(data->pipe_fd[node->idx]) < 0)
 		ft_putendl_fd(strerror(errno), STDERR_FILENO);
 }

--- a/minishell/src/utils/parse/utils_parse.c
+++ b/minishell/src/utils/parse/utils_parse.c
@@ -22,7 +22,7 @@ char	**copy_env(char **env)
 		return (NULL);
 	i = 0;
 	while (env[i])
-	{	
+	{
 		ret[i] = ft_strdup(env[i]);
 		i++;
 	}

--- a/minishell/src/utils/parse/utils_parse_list2.c
+++ b/minishell/src/utils/parse/utils_parse_list2.c
@@ -43,8 +43,13 @@ void	set_list_idx(t_double_list *list)
 	cur = list->head;
 	while (cur)
 	{
-		cur->idx = i;
-		i++;
+		if (cur->pipe_type != NO_PIPE)
+		{
+			cur->idx = i;
+			i++;
+		}
+		else
+			cur->idx = -1;
 		cur = cur->next;
 	}
 }


### PR DESCRIPTION
1. init -> idx increase only if node->cmd_args[0] is cmd (not redirection)
2. when redirection idx will -1 (for ft_pipe)
3. add function : cmd will run with absolute path
4. builtin export -> env error fixed
5. define exit code by WEXITSTATUS

TDL
1. make history (by readline) ...